### PR TITLE
Prevent listening to 2 ports

### DIFF
--- a/launch.bash
+++ b/launch.bash
@@ -7,7 +7,7 @@ if [ -z "$SECRET_TOKEN" -a ! -f "config/initializers/__secret_token.rb" ]; then
   echo "Errbit::Application.config.secret_token = '$(bundle exec rake secret)'" > config/initializers/__secret_token.rb
 fi
 if [ "$1" == "web" ]; then
-  bundle exec unicorn -p 3000 -c ./config/unicorn.default.rb
+  bundle exec unicorn -c ./config/unicorn.default.rb
 elif [ "$1" == "seed" ]; then
   bundle exec rake errbit:bootstrap
 elif [ "$1" == "upgrade" ]; then


### PR DESCRIPTION
Remove -p 3000 because it is starting second unicorn instance on 3000 port
the first one is on specified in unicorn.default.rb